### PR TITLE
Export StateWithValue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as R from "react";
-interface StateWithValue<T> {
+export interface StateWithValue<T> {
   use: () => [
     T,
     (newState: T | ((prev: T) => T), ac?: (newState: T) => any) => any


### PR DESCRIPTION
We want to be able to type multiple states in an array, so it would be really helpful to have this type exported.

Especially because we can't go with the return type of the generic:

`ReturnType<typeof newRidgeState>` 

Great project, thanks for sharing & maintaining it!